### PR TITLE
Wpf: Fix TabControl autosizing for all tabs, not just initial tab

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
@@ -1,17 +1,53 @@
 using System;
+using System.Linq;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
+using sw = System.Windows;
 using Eto.Forms;
 using Eto.Drawing;
+using Eto.Wpf.CustomControls;
 
 namespace Eto.Wpf.Forms.Controls
 {
 	public class TabControlHandler : WpfContainer<swc.TabControl, TabControl, TabControl.ICallback>, TabControl.IHandler
 	{
+		class EtoTabControl : swc.TabControl
+		{
+			protected override sw.Size MeasureOverride(sw.Size constraint)
+			{
+				// once loaded, act as normal
+				if (IsLoaded)
+					return base.MeasureOverride(constraint);
+
+				// not loaded yet, let's calculate size based on all tabs
+				var size = new sw.Size(0, 0);
+				var selectedSize = new sw.Size(0, 0);
+				var selected = SelectedItem as swc.TabItem;
+
+				foreach (var tab in Items.Cast<swc.TabItem>())
+				{
+					var tabContent = tab.Content as sw.FrameworkElement;
+					if (tabContent == null)
+						continue;
+					tabContent.Measure(constraint);
+					var tabSize = tabContent.DesiredSize;
+					if (tab == selected)
+						selectedSize = tabSize;
+					size.Width = Math.Max(tabSize.Width, size.Width);
+					size.Height = Math.Max(tabSize.Height, size.Height);
+				}
+				var baseSize = base.MeasureOverride(constraint);
+				// calculate size of the border around the content based on selected tab's content size
+				var borderSize = new sw.Size(baseSize.Width - selectedSize.Width, baseSize.Height - selectedSize.Height);
+				// return max height with border
+				return new sw.Size(size.Width + borderSize.Width, size.Height + borderSize.Height);
+			}
+		}
+
 		bool disableSelectedIndexChanged;
 		public TabControlHandler()
 		{
-			Control = new swc.TabControl();
+			Control = new EtoTabControl();
 		}
 
 		public override void OnLoadComplete(EventArgs e)

--- a/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
@@ -24,7 +24,12 @@ namespace Eto.Wpf.Forms.Controls
 			header.Children.Add(headerText);
 			Control.Header = header;
 
-			Control.Content = content = new swc.DockPanel { LastChildFill = true };
+			Control.Content = content = new swc.DockPanel
+			{
+				LastChildFill = true,
+				VerticalAlignment = sw.VerticalAlignment.Stretch,
+				HorizontalAlignment = sw.HorizontalAlignment.Stretch
+			};
 		}
 
 		public string Text


### PR DESCRIPTION
TabPage content also stretches to fill if only a single control.